### PR TITLE
[ENG-6543]Upgrade to node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Tag the deployment
-        uses: daily-co/create-tag-action@v1.0
+        uses: daily-co/create-tag-action@v1
         with:
           app-name: 'my-application'
           environment: 'qa'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Create Tag'
-description: 'Creates tags in GitHub for deployments'
+name: "Create Tag"
+description: "Creates tags in GitHub for deployments"
 inputs:
   app-name:
     description: 'Name of the app to include in tag, e.g. "dashboard"'
@@ -8,13 +8,13 @@ inputs:
     description: 'Environment to which the deployment was made, e.g. "prod"'
     required: true
   github-token:
-    description: 'API token for GitHub REST API'
+    description: "API token for GitHub REST API"
     required: true
 outputs:
   tag:
-    description: 'Final tag applied'
+    description: "Final tag applied"
 runs:
   using: 'node12'
   # 'main' below needs to be relative to repo root for testing with 'act'
   # For running in GitHub, should be relative to 'action.yml' location
-  main: 'dist/index.js'
+  main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ outputs:
   tag:
     description: "Final tag applied"
 runs:
-  using: 'node12'
+  using: "node16"
   # 'main' below needs to be relative to repo root for testing with 'act'
   # For running in GitHub, should be relative to 'action.yml' location
   main: "dist/index.js"


### PR DESCRIPTION
See linear ticket https://linear.app/dailyco/issue/ENG-6543/upgrade-create-tag-action-to-use-node16

With this change, I'll also:

- bump the version of the action to v1.2
- Release a v1.2 tag
- Update the existing v1 tag to be the same as v1.2 (a useful pattern for existing workflows to not have to change assuming I didn't bump them explicitly to v1.1 the last time I played with this)