### PR TITLE
Add optional inputs for owner and repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,10 @@ inputs:
     required: false
   github-token:
     description: "API token for GitHub REST API"
-    required: true
+    required: false
   sha:
     description: "commit sha to tag"
-    required: true
+    required: false
   owner:
     description: "owner of the repository"
     required: false
@@ -23,7 +23,7 @@ outputs:
   tag:
     description: "Final tag applied"
 runs:
-  using: "node16"
+  using: "node20"
   # 'main' below needs to be relative to repo root for testing with 'act'
   # For running in GitHub, should be relative to 'action.yml' location
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   environment:
     description: 'Environment to which the deployment was made, e.g. "prod"'
-    required: true
+    required: false
   github-token:
     description: "API token for GitHub REST API"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,12 @@ inputs:
   sha:
     description: "commit sha to tag"
     required: true
+  owner:
+    description: "owner of the repository"
+    required: false
+  repo:
+    description: "name of the repository"
+    required: false
 outputs:
   tag:
     description: "Final tag applied"

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 1411:
+/***/ 4724:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -27,8 +27,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
-const os = __importStar(__nccwpck_require__(2037));
-const utils_1 = __nccwpck_require__(7500);
+const os = __importStar(__nccwpck_require__(857));
+const utils_1 = __nccwpck_require__(1224);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 7342:
+/***/ 4786:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,12 +135,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIDToken = exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.notice = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(1411);
-const file_command_1 = __nccwpck_require__(7512);
-const utils_1 = __nccwpck_require__(7500);
-const os = __importStar(__nccwpck_require__(2037));
-const path = __importStar(__nccwpck_require__(1017));
-const oidc_utils_1 = __nccwpck_require__(9246);
+const command_1 = __nccwpck_require__(4724);
+const file_command_1 = __nccwpck_require__(2739);
+const utils_1 = __nccwpck_require__(1224);
+const os = __importStar(__nccwpck_require__(857));
+const path = __importStar(__nccwpck_require__(6928));
+const oidc_utils_1 = __nccwpck_require__(1240);
 /**
  * The code to exit an action
  */
@@ -425,17 +425,17 @@ exports.getIDToken = getIDToken;
 /**
  * Summary exports
  */
-var summary_1 = __nccwpck_require__(799);
+var summary_1 = __nccwpck_require__(6773);
 Object.defineProperty(exports, "summary", ({ enumerable: true, get: function () { return summary_1.summary; } }));
 /**
  * @deprecated use core.summary
  */
-var summary_2 = __nccwpck_require__(799);
+var summary_2 = __nccwpck_require__(6773);
 Object.defineProperty(exports, "markdownSummary", ({ enumerable: true, get: function () { return summary_2.markdownSummary; } }));
 /**
  * Path exports
  */
-var path_utils_1 = __nccwpck_require__(1672);
+var path_utils_1 = __nccwpck_require__(1222);
 Object.defineProperty(exports, "toPosixPath", ({ enumerable: true, get: function () { return path_utils_1.toPosixPath; } }));
 Object.defineProperty(exports, "toWin32Path", ({ enumerable: true, get: function () { return path_utils_1.toWin32Path; } }));
 Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: function () { return path_utils_1.toPlatformPath; } }));
@@ -443,7 +443,7 @@ Object.defineProperty(exports, "toPlatformPath", ({ enumerable: true, get: funct
 
 /***/ }),
 
-/***/ 7512:
+/***/ 2739:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -472,10 +472,10 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(7147));
-const os = __importStar(__nccwpck_require__(2037));
-const uuid_1 = __nccwpck_require__(5847);
-const utils_1 = __nccwpck_require__(7500);
+const fs = __importStar(__nccwpck_require__(9896));
+const os = __importStar(__nccwpck_require__(857));
+const uuid_1 = __nccwpck_require__(1674);
+const utils_1 = __nccwpck_require__(1224);
 function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -508,7 +508,7 @@ exports.prepareKeyValueMessage = prepareKeyValueMessage;
 
 /***/ }),
 
-/***/ 9246:
+/***/ 1240:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -524,9 +524,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.OidcClient = void 0;
-const http_client_1 = __nccwpck_require__(2506);
-const auth_1 = __nccwpck_require__(4001);
-const core_1 = __nccwpck_require__(7342);
+const http_client_1 = __nccwpck_require__(8949);
+const auth_1 = __nccwpck_require__(4907);
+const core_1 = __nccwpck_require__(4786);
 class OidcClient {
     static createHttpClient(allowRetry = true, maxRetry = 10) {
         const requestOptions = {
@@ -592,7 +592,7 @@ exports.OidcClient = OidcClient;
 
 /***/ }),
 
-/***/ 1672:
+/***/ 1222:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -618,7 +618,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-const path = __importStar(__nccwpck_require__(1017));
+const path = __importStar(__nccwpck_require__(6928));
 /**
  * toPosixPath converts the given path to the posix form. On Windows, \\ will be
  * replaced with /.
@@ -657,7 +657,7 @@ exports.toPlatformPath = toPlatformPath;
 
 /***/ }),
 
-/***/ 799:
+/***/ 6773:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -673,8 +673,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
-const os_1 = __nccwpck_require__(2037);
-const fs_1 = __nccwpck_require__(7147);
+const os_1 = __nccwpck_require__(857);
+const fs_1 = __nccwpck_require__(9896);
 const { access, appendFile, writeFile } = fs_1.promises;
 exports.SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY';
 exports.SUMMARY_DOCS_URL = 'https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary';
@@ -947,7 +947,7 @@ exports.summary = _summary;
 
 /***/ }),
 
-/***/ 7500:
+/***/ 1224:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -994,7 +994,7 @@ exports.toCommandProperties = toCommandProperties;
 
 /***/ }),
 
-/***/ 4001:
+/***/ 4907:
 /***/ (function(__unused_webpack_module, exports) {
 
 "use strict";
@@ -1082,7 +1082,7 @@ exports.PersonalAccessTokenCredentialHandler = PersonalAccessTokenCredentialHand
 
 /***/ }),
 
-/***/ 2506:
+/***/ 8949:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1118,10 +1118,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.HttpClient = exports.isHttps = exports.HttpClientResponse = exports.HttpClientError = exports.getProxyUrl = exports.MediaTypes = exports.Headers = exports.HttpCodes = void 0;
-const http = __importStar(__nccwpck_require__(3685));
-const https = __importStar(__nccwpck_require__(5687));
-const pm = __importStar(__nccwpck_require__(8034));
-const tunnel = __importStar(__nccwpck_require__(5197));
+const http = __importStar(__nccwpck_require__(8611));
+const https = __importStar(__nccwpck_require__(5692));
+const pm = __importStar(__nccwpck_require__(7037));
+const tunnel = __importStar(__nccwpck_require__(3232));
 var HttpCodes;
 (function (HttpCodes) {
     HttpCodes[HttpCodes["OK"] = 200] = "OK";
@@ -1694,7 +1694,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 
 /***/ }),
 
-/***/ 8034:
+/***/ 7037:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1777,15 +1777,15 @@ function isLoopbackAddress(host) {
 
 /***/ }),
 
-/***/ 8680:
+/***/ 7838:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Context = void 0;
-const fs_1 = __nccwpck_require__(7147);
-const os_1 = __nccwpck_require__(2037);
+const fs_1 = __nccwpck_require__(9896);
+const os_1 = __nccwpck_require__(857);
 class Context {
     /**
      * Hydrate the context from the environment
@@ -1834,7 +1834,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 8676:
+/***/ 7898:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1860,8 +1860,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(8680));
-const utils_1 = __nccwpck_require__(2856);
+const Context = __importStar(__nccwpck_require__(7838));
+const utils_1 = __nccwpck_require__(1420);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -1877,7 +1877,7 @@ exports.getOctokit = getOctokit;
 
 /***/ }),
 
-/***/ 6747:
+/***/ 5910:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1903,7 +1903,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__nccwpck_require__(2786));
+const httpClient = __importStar(__nccwpck_require__(7170));
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -1927,7 +1927,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 2856:
+/***/ 1420:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1953,12 +1953,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(8680));
-const Utils = __importStar(__nccwpck_require__(6747));
+const Context = __importStar(__nccwpck_require__(7838));
+const Utils = __importStar(__nccwpck_require__(5910));
 // octokit + plugins
-const core_1 = __nccwpck_require__(2680);
-const plugin_rest_endpoint_methods_1 = __nccwpck_require__(86);
-const plugin_paginate_rest_1 = __nccwpck_require__(608);
+const core_1 = __nccwpck_require__(9387);
+const plugin_rest_endpoint_methods_1 = __nccwpck_require__(5129);
+const plugin_paginate_rest_1 = __nccwpck_require__(3656);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
 const defaults = {
@@ -1988,16 +1988,16 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 2786:
+/***/ 7170:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const url = __nccwpck_require__(7310);
-const http = __nccwpck_require__(3685);
-const https = __nccwpck_require__(5687);
-const pm = __nccwpck_require__(3557);
+const url = __nccwpck_require__(7016);
+const http = __nccwpck_require__(8611);
+const https = __nccwpck_require__(5692);
+const pm = __nccwpck_require__(4622);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -2407,7 +2407,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(5197);
+                tunnel = __nccwpck_require__(3232);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -2527,13 +2527,13 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 3557:
+/***/ 4622:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const url = __nccwpck_require__(7310);
+const url = __nccwpck_require__(7016);
 function getProxyUrl(reqUrl) {
     let usingSsl = reqUrl.protocol === 'https:';
     let proxyUrl;
@@ -2593,7 +2593,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 5758:
+/***/ 66:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -2650,7 +2650,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 2680:
+/***/ 9387:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2658,11 +2658,11 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __nccwpck_require__(5098);
-var beforeAfterHook = __nccwpck_require__(7564);
-var request = __nccwpck_require__(3163);
-var graphql = __nccwpck_require__(6099);
-var authToken = __nccwpck_require__(5758);
+var universalUserAgent = __nccwpck_require__(2049);
+var beforeAfterHook = __nccwpck_require__(5146);
+var request = __nccwpck_require__(5233);
+var graphql = __nccwpck_require__(4489);
+var authToken = __nccwpck_require__(66);
 
 function _defineProperty(obj, key, value) {
   if (key in obj) {
@@ -2834,7 +2834,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 9466:
+/***/ 7321:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2844,8 +2844,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var isPlainObject = _interopDefault(__nccwpck_require__(5877));
-var universalUserAgent = __nccwpck_require__(5098);
+var isPlainObject = _interopDefault(__nccwpck_require__(7301));
+var universalUserAgent = __nccwpck_require__(2049);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -3221,7 +3221,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 6099:
+/***/ 4489:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3229,8 +3229,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(3163);
-var universalUserAgent = __nccwpck_require__(5098);
+var request = __nccwpck_require__(5233);
+var universalUserAgent = __nccwpck_require__(2049);
 
 const VERSION = "4.5.2";
 
@@ -3314,7 +3314,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 608:
+/***/ 3656:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3452,7 +3452,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 86:
+/***/ 5129:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4667,7 +4667,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 7442:
+/***/ 7510:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4677,8 +4677,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(9785);
-var once = _interopDefault(__nccwpck_require__(4178));
+var deprecation = __nccwpck_require__(9624);
+var once = _interopDefault(__nccwpck_require__(3062));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -4730,7 +4730,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 3163:
+/***/ 5233:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4740,11 +4740,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(9466);
-var universalUserAgent = __nccwpck_require__(5098);
-var isPlainObject = _interopDefault(__nccwpck_require__(5877));
-var nodeFetch = _interopDefault(__nccwpck_require__(8792));
-var requestError = __nccwpck_require__(7442);
+var endpoint = __nccwpck_require__(7321);
+var universalUserAgent = __nccwpck_require__(2049);
+var isPlainObject = _interopDefault(__nccwpck_require__(7301));
+var nodeFetch = _interopDefault(__nccwpck_require__(7759));
+var requestError = __nccwpck_require__(7510);
 
 const VERSION = "5.4.7";
 
@@ -4886,12 +4886,12 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 7564:
+/***/ 5146:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(2979)
-var addHook = __nccwpck_require__(580)
-var removeHook = __nccwpck_require__(4865)
+var register = __nccwpck_require__(7757)
+var addHook = __nccwpck_require__(2829)
+var removeHook = __nccwpck_require__(1256)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -4950,7 +4950,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 580:
+/***/ 2829:
 /***/ ((module) => {
 
 module.exports = addHook
@@ -5003,7 +5003,7 @@ function addHook (state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 2979:
+/***/ 7757:
 /***/ ((module) => {
 
 module.exports = register
@@ -5038,7 +5038,7 @@ function register (state, name, method, options) {
 
 /***/ }),
 
-/***/ 4865:
+/***/ 1256:
 /***/ ((module) => {
 
 module.exports = removeHook
@@ -5062,7 +5062,7 @@ function removeHook (state, name, method) {
 
 /***/ }),
 
-/***/ 9785:
+/***/ 9624:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5090,7 +5090,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 5877:
+/***/ 7301:
 /***/ ((module) => {
 
 "use strict";
@@ -5134,7 +5134,7 @@ module.exports = isPlainObject;
 
 /***/ }),
 
-/***/ 8792:
+/***/ 7759:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -5144,11 +5144,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Stream = _interopDefault(__nccwpck_require__(2781));
-var http = _interopDefault(__nccwpck_require__(3685));
-var Url = _interopDefault(__nccwpck_require__(7310));
-var https = _interopDefault(__nccwpck_require__(5687));
-var zlib = _interopDefault(__nccwpck_require__(9796));
+var Stream = _interopDefault(__nccwpck_require__(2203));
+var http = _interopDefault(__nccwpck_require__(8611));
+var Url = _interopDefault(__nccwpck_require__(7016));
+var https = _interopDefault(__nccwpck_require__(5692));
+var zlib = _interopDefault(__nccwpck_require__(3106));
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -5299,7 +5299,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = (__nccwpck_require__(2047).convert);
+	convert = (__nccwpck_require__(8544).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -6784,10 +6784,10 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 4178:
+/***/ 3062:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(6215)
+var wrappy = __nccwpck_require__(7766)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -6833,27 +6833,27 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 5197:
+/***/ 3232:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(253);
+module.exports = __nccwpck_require__(1184);
 
 
 /***/ }),
 
-/***/ 253:
+/***/ 1184:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(1808);
-var tls = __nccwpck_require__(4404);
-var http = __nccwpck_require__(3685);
-var https = __nccwpck_require__(5687);
-var events = __nccwpck_require__(2361);
-var assert = __nccwpck_require__(9491);
-var util = __nccwpck_require__(3837);
+var net = __nccwpck_require__(9278);
+var tls = __nccwpck_require__(4756);
+var http = __nccwpck_require__(8611);
+var https = __nccwpck_require__(5692);
+var events = __nccwpck_require__(4434);
+var assert = __nccwpck_require__(2613);
+var util = __nccwpck_require__(9023);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -7113,7 +7113,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 5098:
+/***/ 2049:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7139,7 +7139,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 5847:
+/***/ 1674:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7203,29 +7203,29 @@ Object.defineProperty(exports, "parse", ({
   }
 }));
 
-var _v = _interopRequireDefault(__nccwpck_require__(2139));
+var _v = _interopRequireDefault(__nccwpck_require__(9181));
 
-var _v2 = _interopRequireDefault(__nccwpck_require__(4165));
+var _v2 = _interopRequireDefault(__nccwpck_require__(219));
 
-var _v3 = _interopRequireDefault(__nccwpck_require__(7378));
+var _v3 = _interopRequireDefault(__nccwpck_require__(6786));
 
-var _v4 = _interopRequireDefault(__nccwpck_require__(9542));
+var _v4 = _interopRequireDefault(__nccwpck_require__(4673));
 
-var _nil = _interopRequireDefault(__nccwpck_require__(347));
+var _nil = _interopRequireDefault(__nccwpck_require__(6741));
 
-var _version = _interopRequireDefault(__nccwpck_require__(7309));
+var _version = _interopRequireDefault(__nccwpck_require__(7982));
 
-var _validate = _interopRequireDefault(__nccwpck_require__(387));
+var _validate = _interopRequireDefault(__nccwpck_require__(7566));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(9859));
+var _stringify = _interopRequireDefault(__nccwpck_require__(5319));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(6692));
+var _parse = _interopRequireDefault(__nccwpck_require__(7705));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /***/ }),
 
-/***/ 2496:
+/***/ 7062:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7236,7 +7236,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7255,7 +7255,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 347:
+/***/ 6741:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7270,7 +7270,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6692:
+/***/ 7705:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7281,7 +7281,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(387));
+var _validate = _interopRequireDefault(__nccwpck_require__(7566));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7322,7 +7322,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 5089:
+/***/ 9453:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7337,7 +7337,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 2635:
+/***/ 8863:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7348,7 +7348,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = rng;
 
-var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7368,7 +7368,7 @@ function rng() {
 
 /***/ }),
 
-/***/ 977:
+/***/ 3281:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7379,7 +7379,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+var _crypto = _interopRequireDefault(__nccwpck_require__(6982));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7398,7 +7398,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9859:
+/***/ 5319:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7409,7 +7409,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(387));
+var _validate = _interopRequireDefault(__nccwpck_require__(7566));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7444,7 +7444,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 2139:
+/***/ 9181:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7455,9 +7455,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(2635));
+var _rng = _interopRequireDefault(__nccwpck_require__(8863));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(9859));
+var _stringify = _interopRequireDefault(__nccwpck_require__(5319));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7558,7 +7558,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 4165:
+/***/ 219:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7569,9 +7569,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(4479));
+var _v = _interopRequireDefault(__nccwpck_require__(5672));
 
-var _md = _interopRequireDefault(__nccwpck_require__(2496));
+var _md = _interopRequireDefault(__nccwpck_require__(7062));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7581,7 +7581,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 4479:
+/***/ 5672:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7593,9 +7593,9 @@ Object.defineProperty(exports, "__esModule", ({
 exports["default"] = _default;
 exports.URL = exports.DNS = void 0;
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(9859));
+var _stringify = _interopRequireDefault(__nccwpck_require__(5319));
 
-var _parse = _interopRequireDefault(__nccwpck_require__(6692));
+var _parse = _interopRequireDefault(__nccwpck_require__(7705));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7666,7 +7666,7 @@ function _default(name, version, hashfunc) {
 
 /***/ }),
 
-/***/ 7378:
+/***/ 6786:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7677,9 +7677,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _rng = _interopRequireDefault(__nccwpck_require__(2635));
+var _rng = _interopRequireDefault(__nccwpck_require__(8863));
 
-var _stringify = _interopRequireDefault(__nccwpck_require__(9859));
+var _stringify = _interopRequireDefault(__nccwpck_require__(5319));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7710,7 +7710,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 9542:
+/***/ 4673:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7721,9 +7721,9 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _v = _interopRequireDefault(__nccwpck_require__(4479));
+var _v = _interopRequireDefault(__nccwpck_require__(5672));
 
-var _sha = _interopRequireDefault(__nccwpck_require__(977));
+var _sha = _interopRequireDefault(__nccwpck_require__(3281));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7733,7 +7733,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 387:
+/***/ 7566:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7744,7 +7744,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _regex = _interopRequireDefault(__nccwpck_require__(5089));
+var _regex = _interopRequireDefault(__nccwpck_require__(9453));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7757,7 +7757,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 7309:
+/***/ 7982:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -7768,7 +7768,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = void 0;
 
-var _validate = _interopRequireDefault(__nccwpck_require__(387));
+var _validate = _interopRequireDefault(__nccwpck_require__(7566));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -7785,7 +7785,7 @@ exports["default"] = _default;
 
 /***/ }),
 
-/***/ 6215:
+/***/ 7766:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -7825,7 +7825,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 2047:
+/***/ 8544:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -7833,7 +7833,7 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
-/***/ 9491:
+/***/ 2613:
 /***/ ((module) => {
 
 "use strict";
@@ -7841,7 +7841,7 @@ module.exports = require("assert");
 
 /***/ }),
 
-/***/ 6113:
+/***/ 6982:
 /***/ ((module) => {
 
 "use strict";
@@ -7849,7 +7849,7 @@ module.exports = require("crypto");
 
 /***/ }),
 
-/***/ 2361:
+/***/ 4434:
 /***/ ((module) => {
 
 "use strict";
@@ -7857,7 +7857,7 @@ module.exports = require("events");
 
 /***/ }),
 
-/***/ 7147:
+/***/ 9896:
 /***/ ((module) => {
 
 "use strict";
@@ -7865,7 +7865,7 @@ module.exports = require("fs");
 
 /***/ }),
 
-/***/ 3685:
+/***/ 8611:
 /***/ ((module) => {
 
 "use strict";
@@ -7873,7 +7873,7 @@ module.exports = require("http");
 
 /***/ }),
 
-/***/ 5687:
+/***/ 5692:
 /***/ ((module) => {
 
 "use strict";
@@ -7881,7 +7881,7 @@ module.exports = require("https");
 
 /***/ }),
 
-/***/ 1808:
+/***/ 9278:
 /***/ ((module) => {
 
 "use strict";
@@ -7889,7 +7889,7 @@ module.exports = require("net");
 
 /***/ }),
 
-/***/ 2037:
+/***/ 857:
 /***/ ((module) => {
 
 "use strict";
@@ -7897,7 +7897,7 @@ module.exports = require("os");
 
 /***/ }),
 
-/***/ 1017:
+/***/ 6928:
 /***/ ((module) => {
 
 "use strict";
@@ -7905,7 +7905,7 @@ module.exports = require("path");
 
 /***/ }),
 
-/***/ 2781:
+/***/ 2203:
 /***/ ((module) => {
 
 "use strict";
@@ -7913,7 +7913,7 @@ module.exports = require("stream");
 
 /***/ }),
 
-/***/ 4404:
+/***/ 4756:
 /***/ ((module) => {
 
 "use strict";
@@ -7921,7 +7921,7 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 7310:
+/***/ 7016:
 /***/ ((module) => {
 
 "use strict";
@@ -7929,7 +7929,7 @@ module.exports = require("url");
 
 /***/ }),
 
-/***/ 3837:
+/***/ 9023:
 /***/ ((module) => {
 
 "use strict";
@@ -7937,7 +7937,7 @@ module.exports = require("util");
 
 /***/ }),
 
-/***/ 9796:
+/***/ 3106:
 /***/ ((module) => {
 
 "use strict";
@@ -7984,10 +7984,8 @@ module.exports = require("zlib");
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
-(() => {
-const core = __nccwpck_require__(7342);
-const github = __nccwpck_require__(8676);
+const core = __nccwpck_require__(4786);
+const github = __nccwpck_require__(7898);
 
 function stringifyDate(date) {
   return date.toISOString().substring(0, 10);
@@ -7995,22 +7993,27 @@ function stringifyDate(date) {
 
 function getTagName(appName, environment) {
   date = stringifyDate(new Date());
-  return `${appName}-${date}-${environment}`;
+  let tag = `${appName}-${date}`;
+  if (environment) {
+    tag = `${tag}-${environment}`;
+  }
+  return tag;
 }
 
 async function run() {
   try {
-    const appName = core.getInput("app-name");
+    const appName = core.getInput("app-name", {required: true});
     if (!appName) {
       core.setFailed('Input "app-name" is missing');
     }
 
-    const environment = core.getInput("environment");
-    if (!environment) {
-      core.setFailed('Input "environment" is missing');
+    let environment = "";
+    const environmentInput = core.getInput("environment", {required: false});
+    if (environmentInput) {
+      environment = environmentInput;
     }
 
-    let githubToken = core.getInput("github-token");
+    let githubToken = core.getInput("github-token", {required: false});
     if (!githubToken) {
       if (process.env.GITHUB_TOKEN) {
         githubToken = process.env.GITHUB_TOKEN;
@@ -8022,18 +8025,30 @@ async function run() {
     }
 
     const octokit = github.getOctokit(githubToken);
+    let { owner, repo } = github.context.repo;
+
+    const repoInput = core.getInput("repo", {required: false});
+    if (repoInput) {
+      repo = repoInput;
+    }
+
+    const ownerInput = core.getInput("owner", {required: false});
+    if (ownerInput) {
+      owner = ownerInput;
+    }
 
     const tagName = getTagName(appName, environment);
     core.setOutput("tag", tagName);
     const tagMessage = `${tagName} deployed via GitHub Actions`;
 
-    const { owner, repo } = github.context.repo;
-    const sha = core.getInput("sha") || process.env.GITHUB_SHA;
+    const sha = core.getInput("sha", {required: false}) || process.env.GITHUB_SHA;
     if (!sha) {
       core.setFailed(
         'SHA to tag must be provided as input "sha" or environment variable "GITHUB_SHA"'
       );
     }
+
+    console.log(`Repo: ${owner}/${repo}, Tag: ${tagName}, SHA: ${sha}`);
 
     const createdTag = await octokit.git.createTag({
       owner,
@@ -8091,8 +8106,6 @@ async function run() {
 }
 
 run();
-
-})();
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/index.js
+++ b/index.js
@@ -7,7 +7,11 @@ function stringifyDate(date) {
 
 function getTagName(appName, environment) {
   date = stringifyDate(new Date());
-  return `${appName}-${date}-${environment}`;
+  let tag = `${appName}-${date}`;
+  if (environment) {
+    tag = `${tag}-${environment}`
+  }
+  return tag;
 }
 
 async function run() {
@@ -17,9 +21,10 @@ async function run() {
       core.setFailed('Input "app-name" is missing');
     }
 
-    const environment = core.getInput("environment");
-    if (!environment) {
-      core.setFailed('Input "environment" is missing');
+    let environment = "";
+    const environmentInput = core.getInput("environment");
+    if (environmentInput) {
+      environment = environmentInput;
     }
 
     let githubToken = core.getInput("github-token");

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function getTagName(appName, environment) {
   date = stringifyDate(new Date());
   let tag = `${appName}-${date}`;
   if (environment) {
-    tag = `${tag}-${environment}`
+    tag = `${tag}-${environment}`;
   }
   return tag;
 }
@@ -61,6 +61,8 @@ async function run() {
         'SHA to tag must be provided as input "sha" or environment variable "GITHUB_SHA"'
       );
     }
+
+    console.log(`Repo: ${owner}/${repo}, Tag: ${tagName}, SHA: ${sha}`);
 
     const createdTag = await octokit.git.createTag({
       owner,

--- a/index.js
+++ b/index.js
@@ -34,12 +34,22 @@ async function run() {
     }
 
     const octokit = github.getOctokit(githubToken);
+    let { owner, repo } = github.context.repo;
+
+    const repoInput = core.getInput("repo");
+    if (repoInput) {
+      repo = repoInput;
+    }
+
+    const ownerInput = core.getInput("owner");
+    if (ownerInput) {
+      owner = ownerInput;
+    }
 
     const tagName = getTagName(appName, environment);
     core.setOutput("tag", tagName);
     const tagMessage = `${tagName} deployed via GitHub Actions`;
 
-    const { owner, repo } = github.context.repo;
     const sha = core.getInput("sha") || process.env.GITHUB_SHA;
     if (!sha) {
       core.setFailed(

--- a/index.js
+++ b/index.js
@@ -16,18 +16,18 @@ function getTagName(appName, environment) {
 
 async function run() {
   try {
-    const appName = core.getInput("app-name");
+    const appName = core.getInput("app-name", {required: true});
     if (!appName) {
       core.setFailed('Input "app-name" is missing');
     }
 
     let environment = "";
-    const environmentInput = core.getInput("environment");
+    const environmentInput = core.getInput("environment", {required: false});
     if (environmentInput) {
       environment = environmentInput;
     }
 
-    let githubToken = core.getInput("github-token");
+    let githubToken = core.getInput("github-token", {required: false});
     if (!githubToken) {
       if (process.env.GITHUB_TOKEN) {
         githubToken = process.env.GITHUB_TOKEN;
@@ -41,12 +41,12 @@ async function run() {
     const octokit = github.getOctokit(githubToken);
     let { owner, repo } = github.context.repo;
 
-    const repoInput = core.getInput("repo");
+    const repoInput = core.getInput("repo", {required: false});
     if (repoInput) {
       repo = repoInput;
     }
 
-    const ownerInput = core.getInput("owner");
+    const ownerInput = core.getInput("owner", {required: false});
     if (ownerInput) {
       owner = ownerInput;
     }
@@ -55,7 +55,7 @@ async function run() {
     core.setOutput("tag", tagName);
     const tagMessage = `${tagName} deployed via GitHub Actions`;
 
-    const sha = core.getInput("sha") || process.env.GITHUB_SHA;
+    const sha = core.getInput("sha", {required: false}) || process.env.GITHUB_SHA;
     if (!sha) {
       core.setFailed(
         'SHA to tag must be provided as input "sha" or environment variable "GITHUB_SHA"'


### PR DESCRIPTION
Updates the daily-co/create-tag-action so that it can be used in a cross-repository context.  Made the environment optional so that tagging format is more flexible, and added inputs to the action for the owner and repo, which allows the tagging to happen cross-repository.